### PR TITLE
don't include padding if no skip

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -87,7 +87,11 @@ class HeaderPy:
                             break
                     else:
                         break
-                header_formatted = "\n\n" + self._remove_whitespace_from_header(header).rstrip("\r\n") + "\n\n"
+
+                if skip_index == 0:
+                    header_formatted = self._remove_whitespace_from_header(header).rstrip("\r\n") + "\n\n"
+                else:
+                    header_formatted = "\n\n" + self._remove_whitespace_from_header(header).rstrip("\r\n") + "\n\n"
             else:
                 header_formatted = self._remove_whitespace_from_header(header).rstrip("\r\n") + "\n\n"
 


### PR DESCRIPTION
Noticed some extra newlines on top of lines if they had a `skip_lines_that_have` rule and didn't have any lines to skip. This fixes that

config:
```yaml
skip_lines_that_have:
  "\\.py$": ["^#!"]
```

before:
```python
 
 
# SUPER SECRET CONFIDENTIAL
# 
# [2023] - [Infinity and Beyond] ACME Inc
# All Rights Reserved.
# 
# NOTICE: This is super secret info that
# must be protected at all costs.

print("Hello, World!")
```
(I added spaces because github trims leading empty newlines)

after:
```python
# SUPER SECRET CONFIDENTIAL
# 
# [2023] - [Infinity and Beyond] ACME Inc
# All Rights Reserved.
# 
# NOTICE: This is super secret info that
# must be protected at all costs.

print("Hello, World!")
```